### PR TITLE
Feat #23, #21: 액세스 토큰을 재발급하는 API 및 로그인 인증 로직 구현

### DIFF
--- a/src/main/java/yapp/bestFriend/config/JwtConfig.java
+++ b/src/main/java/yapp/bestFriend/config/JwtConfig.java
@@ -1,0 +1,18 @@
+package yapp.bestFriend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import yapp.bestFriend.model.utils.JwtUtil;
+
+@Configuration
+public class JwtConfig {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Bean
+    public JwtUtil jwtUtil(){
+        return new JwtUtil(secret);
+    }
+}

--- a/src/main/java/yapp/bestFriend/config/LoginUserAuditorAware.java
+++ b/src/main/java/yapp/bestFriend/config/LoginUserAuditorAware.java
@@ -5,7 +5,7 @@ import org.springframework.data.domain.AuditorAware;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-import yapp.bestFriend.model.entity.User;
+import yapp.bestFriend.service.user.UserDetails;
 
 import java.util.Optional;
 
@@ -23,7 +23,7 @@ public class LoginUserAuditorAware implements AuditorAware<Long> {
                 || authentication.getPrincipal().equals(ANOYMOUS)) {
             return Optional.empty();
         }
-
-        return Optional.of(((User)authentication.getPrincipal()).getId());
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        return Optional.of(userDetails.getUserId());
     }
 }

--- a/src/main/java/yapp/bestFriend/config/SwaggerConfig.java
+++ b/src/main/java/yapp/bestFriend/config/SwaggerConfig.java
@@ -6,9 +6,15 @@ import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ApiKey;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.SecurityReference;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Swagger 설정
@@ -17,10 +23,29 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @Configuration
 @EnableSwagger2
 public class SwaggerConfig {
+    private ApiKey apiKey(){
+        return new ApiKey("JWT", "Authorization","header");
+    }
+
+    private springfox.documentation.spi.service.contexts.SecurityContext secuityContext(){
+        return springfox.documentation.spi.service.contexts.SecurityContext
+                .builder()
+                .securityReferences(defaultAuth()).build();
+    }
+
+    private List<SecurityReference> defaultAuth() {
+        AuthorizationScope authorizationScope = new AuthorizationScope("global","accessEverything");
+        AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+        authorizationScopes[0] = authorizationScope;
+        return Arrays.asList(new SecurityReference("JWT",authorizationScopes));
+    }
 
     @Bean
     public Docket docket(){
-        return new Docket(DocumentationType.SWAGGER_2).select()
+        return new Docket(DocumentationType.SWAGGER_2)
+                .securityContexts(Arrays.asList(secuityContext()))
+                .securitySchemes(Arrays.asList(apiKey()))
+                .select()
                 .apis(RequestHandlerSelectors.basePackage("yapp.bestFriend.controller"))
                 .paths(PathSelectors.any())
                 .build()

--- a/src/main/java/yapp/bestFriend/config/filter/JwtRequestFilter.java
+++ b/src/main/java/yapp/bestFriend/config/filter/JwtRequestFilter.java
@@ -1,0 +1,61 @@
+package yapp.bestFriend.config.filter;
+
+import io.jsonwebtoken.lang.Strings;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import yapp.bestFriend.model.utils.JwtUtil;
+import yapp.bestFriend.service.user.UserDetailsService;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtRequestFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    @Autowired
+    private UserDetailsService userDetailsService;
+
+    @Autowired
+    private JwtUtil jwtTokenUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
+        String requestTokenHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        Long userId = null;
+        String jwtToken = null;
+
+        if (requestTokenHeader != null && requestTokenHeader.startsWith(BEARER_PREFIX)) {
+            jwtToken = requestTokenHeader.substring(BEARER_PREFIX.length());
+            if (Strings.hasLength(jwtToken) && Strings.countOccurrencesOf(jwtToken, ".") == 2) {
+                try {
+                    userId = jwtTokenUtil.getUserIdFromToken(jwtToken);
+                } catch (Throwable e) {
+
+                }
+            }
+        }
+
+        if (userId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            UserDetails userDetails = userDetailsService.loadUserByUsername(userId.toString());
+            if (jwtTokenUtil.validateToken(jwtToken, (yapp.bestFriend.service.user.UserDetails) userDetails)) {
+                UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                usernamePasswordAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/yapp/bestFriend/controller/api/token/ReplaceTokenController.java
+++ b/src/main/java/yapp/bestFriend/controller/api/token/ReplaceTokenController.java
@@ -1,0 +1,45 @@
+package yapp.bestFriend.controller.api.token;
+
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import yapp.bestFriend.model.dto.DefaultRes;
+import yapp.bestFriend.service.user.SessionService;
+
+import javax.servlet.http.HttpServletRequest;
+
+@Api(tags = {"엑세스 토큰 재발급 API"})
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ReplaceTokenController {
+
+    private final SessionService sessionService;
+
+    @ApiOperation(value = "엑세스 토큰 재발급 API",notes = "리프레시 토큰이 유효하다면 엑세스 토큰을 재발급 합니다.(유효하지 않다면 로그아웃 처리")
+    @ApiResponses(value ={
+            @ApiResponse(code=200, message = "1. 토큰재발급"),
+            @ApiResponse(code=401, message = "1. 요청에러 \n 2. 토큰불일치")
+    })
+    @GetMapping("/token")
+    public ResponseEntity<DefaultRes> replaceToken(
+            HttpServletRequest request
+    ){
+        DefaultRes defaultRes = sessionService.replaceToken(request);
+
+        if (defaultRes.getStatusCode() == HttpStatus.UNAUTHORIZED.value()){
+            return new ResponseEntity<>(defaultRes, HttpStatus.UNAUTHORIZED);
+        }else{
+            return new ResponseEntity<>(defaultRes, HttpStatus.OK);
+        }
+
+    }
+}

--- a/src/main/java/yapp/bestFriend/model/dto/res/ReplaceTokenResponseDto.java
+++ b/src/main/java/yapp/bestFriend/model/dto/res/ReplaceTokenResponseDto.java
@@ -1,0 +1,13 @@
+package yapp.bestFriend.model.dto.res;
+
+import lombok.Getter;
+
+@Getter
+public class ReplaceTokenResponseDto {
+
+    private String accessToken;
+
+    public ReplaceTokenResponseDto(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/src/main/java/yapp/bestFriend/model/entity/BaseTime.java
+++ b/src/main/java/yapp/bestFriend/model/entity/BaseTime.java
@@ -25,7 +25,7 @@ public abstract class BaseTime{
     // Entity가 생성되어 저장될 때 시간이 자동 저장됩니다.
     @CreatedDate
     @Column(updatable = false)
-    private LocalDateTime createAt;
+    private LocalDateTime createdAt;
 
     @CreatedBy
     private Long createdBy;

--- a/src/main/java/yapp/bestFriend/service/auth/KakaoOauth.java
+++ b/src/main/java/yapp/bestFriend/service/auth/KakaoOauth.java
@@ -170,28 +170,32 @@ public class KakaoOauth implements SocialOauth {
 
                     userRepository.save(user);
 
-                    String accessToken = JwtUtil.createAccessToken(user.getId());
+                    String accessToken = JwtUtil.createAccessToken(user.getId());//신규토큰 생성
                     String refreshToken = JwtUtil.createRefreshToken(user.getId());
                     user.setRefreshToken(refreshToken);
 
                     return DefaultRes.response(HttpStatus.OK.value(), "등록성공", new UserSignInResponseDto(accessToken, refreshToken, user.getId(), user.getNickName()));
 
                 }else{
-                    info.setAccessToken(access_token);
-                    userConnectionRepository.save(info);
-
                     User userInfo = userRepository.findByEmail(email);
+                    String accessToken = "", refreshToken= "";
                     if(userInfo != null) {
-                        userInfo.setPassword(access_token);
+                        accessToken = JwtUtil.createAccessToken(userInfo.getId());//신규토큰 생성
+                        refreshToken = JwtUtil.createRefreshToken(userInfo.getId());//신규토큰 생성
+                        info.setAccessToken(accessToken);
+                        userConnectionRepository.save(info);
+
+                        userInfo.setPassword(accessToken);
+                        userInfo.setRefreshToken(refreshToken);
                         userRepository.save(userInfo);
                     }
 
-                    return DefaultRes.response(HttpStatus.OK.value(), "토큰수정완료", new UserSignInResponseDto(access_token, userInfo.getToken(), userInfo.getId(), userInfo.getNickName()));
+                    return DefaultRes.response(HttpStatus.OK.value(), "토큰수정완료", new UserSignInResponseDto(accessToken, refreshToken, info.getId(), info.getNickName()));
                 }
             }
 
         } catch (IOException e) {
-            new IllegalArgumentException("알 수 없는 구글 로그인 Access Token 요청 URL 입니다 :: " + KAKAO_SNS_TOKEN_BASE_URL);
+            new IllegalArgumentException("알 수 없는 카카오 로그인 Access Token 요청 URL 입니다 :: " + KAKAO_SNS_TOKEN_BASE_URL);
         }
 
         return DefaultRes.response(HttpStatus.OK.value(), "등록수정실패");

--- a/src/main/java/yapp/bestFriend/service/user/SessionService.java
+++ b/src/main/java/yapp/bestFriend/service/user/SessionService.java
@@ -1,0 +1,67 @@
+package yapp.bestFriend.service.user;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import yapp.bestFriend.model.dto.DefaultRes;
+import yapp.bestFriend.model.dto.res.ReplaceTokenResponseDto;
+import yapp.bestFriend.model.entity.User;
+import yapp.bestFriend.model.utils.JwtUtil;
+import yapp.bestFriend.repository.UserRepository;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class SessionService {
+
+    private final UserRepository userRepository;
+
+    public DefaultRes replaceToken(HttpServletRequest request){
+
+        String token = request.getHeader("Authorization");
+
+        if (token == null) {
+            return DefaultRes.response(HttpStatus.UNAUTHORIZED.value(), "요청에러");
+        }
+
+        String jwtToken = token.substring("Bearer ".length());
+        Claims claims = JwtUtil.getClaimsFromToken(jwtToken);
+        if (claims == null){
+            return DefaultRes.response(HttpStatus.UNAUTHORIZED.value(), "토큰불일치");
+        }
+
+        String tokenName = claims.get("token_name", String.class);
+        String userGrade = claims.get("user_grade", String.class);
+
+        if(tokenName.equals(JwtUtil.REFRESH_TOKEN_NAME)){
+
+            Long userPk = claims.get("user_pk", Long.class);
+            Boolean check = refreshTokenCheck(userPk, jwtToken);
+            if(check){
+                String accessToken;
+                accessToken = JwtUtil.createAccessToken(userPk);
+                return DefaultRes.response(HttpStatus.OK.value(), "토큰재발급", new ReplaceTokenResponseDto(accessToken));
+            }else{
+                return DefaultRes.response(HttpStatus.UNAUTHORIZED.value(), "토큰불일치");
+            }
+
+        }else{
+            return DefaultRes.response(HttpStatus.UNAUTHORIZED.value(), "토큰불일치");
+        }
+    }
+
+    public Boolean refreshTokenCheck(Long id, String refreshToken){
+        Optional<User> optionalUser = userRepository.findById(id);
+
+        return optionalUser.map(user -> {
+            if(user.getToken().equals(refreshToken)){
+                return true;
+            }else{
+                return false;
+            }
+        }).orElse(false);
+    }
+}

--- a/src/main/java/yapp/bestFriend/service/user/UserDetails.java
+++ b/src/main/java/yapp/bestFriend/service/user/UserDetails.java
@@ -7,6 +7,7 @@ import yapp.bestFriend.model.entity.User;
 import java.util.Arrays;
 import java.util.Collection;
 
+//일반 서비스의 사용자 객체를 Spring Security에서 사용하는 사용자 객체와 호환해주는 어댑터
 public class UserDetails implements org.springframework.security.core.userdetails.UserDetails {
 
     private final User user;
@@ -20,10 +21,13 @@ public class UserDetails implements org.springframework.security.core.userdetail
         return Arrays.asList(new SimpleGrantedAuthority(user.getRole().toString()));
     }
 
+    public long getUserId() {
+        return user.getId();
+    }
+
     @Override
     public String getPassword() {
         return user.getPassword();
-//        return "{noop}" + user.getPassword();
     }
 
     @Override

--- a/src/main/java/yapp/bestFriend/service/user/UserDetailsService.java
+++ b/src/main/java/yapp/bestFriend/service/user/UserDetailsService.java
@@ -7,6 +7,11 @@ import org.springframework.stereotype.Service;
 import yapp.bestFriend.model.entity.User;
 import yapp.bestFriend.repository.UserRepository;
 
+import java.util.Optional;
+
+/**
+ * Spring security에서 로그인 할 때 전달된 정보를 기반으로 DB에서 유저를 가져오는 책임을 가지는 인터페이스
+ */
 @Service
 public class UserDetailsService implements org.springframework.security.core.userdetails.UserDetailsService {
 
@@ -14,13 +19,14 @@ public class UserDetailsService implements org.springframework.security.core.use
     private UserRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String name) throws UsernameNotFoundException {
-        User user = userRepository.findByEmail(name);
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Optional<User> user = userRepository.findById(Long.parseLong(username));
+
         if (user == null) {
             throw new UsernameNotFoundException("404 - User Not Found");
         }
 
-        return new yapp.bestFriend.service.user.UserDetails(user);
+        return new yapp.bestFriend.service.user.UserDetails(user.get());
     }
 
 }

--- a/src/test/java/yapp/bestFriend/controller/SampleControllerTest.java
+++ b/src/test/java/yapp/bestFriend/controller/SampleControllerTest.java
@@ -5,9 +5,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+import yapp.bestFriend.model.utils.JwtUtil;
 import yapp.bestFriend.service.user.UserDetailsService;
 
 import static org.hamcrest.Matchers.is;
@@ -26,7 +30,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *  - Spring Security의 테스트도 지원한다.
  *  - @WebMvcTest를 사용하기 위해 테스트할 특정 컨트롤러 클래스를 명시하도록 한다
  */
-@WebMvcTest(controllers = SampleController.class)
+@WebMvcTest(controllers = SampleController.class, includeFilters = {
+        // to include JwtUtil in spring context
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtUtil.class)})
 class SampleControllerTest {
 
     @Autowired
@@ -38,8 +44,12 @@ class SampleControllerTest {
     @MockBean
     PasswordEncoder passwordEncoder;
 
+    @MockBean
+    private JwtUtil jwtUtil;
+
     @Test
     @DisplayName("샘플 응답 Test")
+    @WithMockUser(roles = "USER")
     public void socialLoginType() throws Exception {
         mvc.perform(get("/sample")
                 .contentType(MediaType.APPLICATION_JSON))
@@ -50,6 +60,7 @@ class SampleControllerTest {
 
     @Test
     @DisplayName("샘플 파라미터 있는 Test")
+    @WithMockUser(roles = "USER")
     public void sample_response_param_test() throws Exception {
         String email = "dkfk2685@naver.com";
         String password = "1234";

--- a/src/test/java/yapp/bestFriend/controller/api/auth/OauthControllerTest.java
+++ b/src/test/java/yapp/bestFriend/controller/api/auth/OauthControllerTest.java
@@ -5,17 +5,25 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
+import yapp.bestFriend.model.dto.DefaultRes;
 import yapp.bestFriend.model.enumClass.SocialLoginType;
+import yapp.bestFriend.model.utils.JwtUtil;
 import yapp.bestFriend.service.auth.OauthService;
 import yapp.bestFriend.service.user.UserDetailsService;
 
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@WebMvcTest(controllers = OauthController.class)
+@WebMvcTest(controllers = OauthController.class, includeFilters = {
+        // to include JwtUtil in spring context
+        @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtUtil.class)})
 class OauthControllerTest {
 
     @Autowired
@@ -30,9 +38,18 @@ class OauthControllerTest {
     @MockBean
     PasswordEncoder passwordEncoder;
 
+    @MockBean
+    private JwtUtil jwtUtil;
+
     @Test
     @DisplayName("소셜 로그인 요청 Test")
     public void social_login_controller_test() throws Exception {
+        DefaultRes<String> result = new DefaultRes<>(HttpStatus.OK.value(),
+                "리다이렉트주소",
+                "testRedirectUrl");
+
+        when(OauthService.request(SocialLoginType.KAKAO)).thenReturn(result);
+
         mvc.perform(get("/api/oauth/{socialLoginType}", SocialLoginType.KAKAO))
                 .andDo(print())
                 .andExpect(status().isOk());


### PR DESCRIPTION
- 로그인 인증 로직 구현
헤더에 액세스 토큰 없이 요청하면 403 에러
![image](https://user-images.githubusercontent.com/40281615/170712950-9dccc912-eebc-4481-a807-f359b1f6e535.png)

- 액세스 토큰 재발급 기능 개발
API: /api/token
METHOD : GET
PARAMETER: 없음
예시: 
curl -X GET "https://localhost:8443/api/token" -H "accept: */*" -H "Authorization: Bearer eyJhbGciOiJIU..."
![image](https://user-images.githubusercontent.com/40281615/170711850-323fbc58-c8ef-47d7-8146-d6ebd0be9a64.png)


**권한로직 추가 후 아래와 같이 테스트 코드 리팩토링**
 - 추가로 ProductControllerTest의 경우 현재 도메인 로직 개발 진행중이기 때문에 conflict를 방지하기 위해 추후 커밋 예정

![220527 jwt 토큰 재발급, api 요청 접근 권한 추가 후 Test Code 수정](https://user-images.githubusercontent.com/40281615/170707777-60938a31-288d-4930-9200-36224bd2098b.png)