### PR TITLE
Fefactor #24: api 요청 시 토큰 검사 후 반환 메시지 세분화

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# 20th-Android-Team-2-BE
-[20th] Android 1팀 BackEnd
+# 💵 절친(절약과 친해지기) 💵
+### 저희 YAPP 20th Android 2팀은 안드로이드와 스프링 부트를 활용하여 절약을 기록하는 Mobile Application을 개발하였습니다.
+
+## 👨‍🔧 Tech Stack
+- Front-END: Kotlin
+- Back-END: Spring Boot, Spring Security, Spring Data JPA, H2, QueryDsl
+- Testing: JUnit5, Mockito
+- Deploy: apache tomcat
+- Language: Java
+- communication: Github, Notion, slack
+- etc: Swagger
+- build: Gradle

--- a/src/main/java/yapp/bestFriend/config/filter/JwtRequestFilter.java
+++ b/src/main/java/yapp/bestFriend/config/filter/JwtRequestFilter.java
@@ -1,5 +1,7 @@
 package yapp.bestFriend.config.filter;
 
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.lang.Strings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
@@ -7,6 +9,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import yapp.bestFriend.model.utils.JwtUtil;
@@ -17,11 +21,16 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 @Component
 public class JwtRequestFilter extends OncePerRequestFilter {
 
     private static final String BEARER_PREFIX = "Bearer ";
+    private static List<RequestMatcher> requestMatchers;
 
     @Autowired
     private UserDetailsService userDetailsService;
@@ -31,19 +40,34 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
+        setRequestMatchers();//필터 검사 대상 제외
+
+        if (isError(request, response)) return;
+
+        chain.doFilter(request, response);
+
+    }
+
+    private boolean isError(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        // anyMatch: 하나라도 일치하면 true 를 반환하고 아닐 경우에는 false 를 반환한다.
+        if(requestMatchers.stream().anyMatch(req -> req.matches(request))) {
+            return false;
+        }
+
         String requestTokenHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (requestTokenHeader == null) {
+            setResponse(request, response, SC_UNAUTHORIZED, "Token not found");
+            return true;
+        }
 
         Long userId = null;
         String jwtToken = null;
 
-        if (requestTokenHeader != null && requestTokenHeader.startsWith(BEARER_PREFIX)) {
+        if (requestTokenHeader.startsWith(BEARER_PREFIX)) {
             jwtToken = requestTokenHeader.substring(BEARER_PREFIX.length());
             if (Strings.hasLength(jwtToken) && Strings.countOccurrencesOf(jwtToken, ".") == 2) {
-                try {
-                    userId = jwtTokenUtil.getUserIdFromToken(jwtToken);
-                } catch (Throwable e) {
-
-                }
+                userId = getUserId(request, response, jwtToken);
+                if (userId == null) return true;
             }
         }
 
@@ -56,6 +80,49 @@ public class JwtRequestFilter extends OncePerRequestFilter {
             }
         }
 
-        chain.doFilter(request, response);
+        return false;
+    }
+
+    /**
+     * 입력된 token 정보를 바탕으로 userId 정보를 꺼낸다.
+     */
+    private Long getUserId(HttpServletRequest request, HttpServletResponse response, String jwtToken) throws IOException {
+        try {
+            return jwtTokenUtil.getUserIdFromToken(jwtToken);
+        }catch (ExpiredJwtException e) {
+            e.printStackTrace();
+            setResponse(request, response, SC_UNAUTHORIZED, "Access Token expired");
+        }catch (JwtException e) {
+            e.printStackTrace();
+            setResponse(request, response, SC_UNAUTHORIZED, "Invalid Access Token");
+        }catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    /**
+     * 한글 출력을 위해 getWriter() 사용
+     */
+    private void setResponse(HttpServletRequest request, HttpServletResponse response, int errorCode, String message) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(errorCode);
+        response.getWriter().println("{ \"message\" : \"" + message
+                + "\", \"status\" : " + errorCode
+                + " }");
+    }
+
+    public void setRequestMatchers() {
+        requestMatchers = Arrays.asList(new AntPathRequestMatcher("/api/oauth/**"),
+                new AntPathRequestMatcher("/swagger-resources/**"),
+                new AntPathRequestMatcher("/h2-console/**"),
+                new AntPathRequestMatcher("/api/token/**"),
+                new AntPathRequestMatcher("/configuration/ui"),
+                new AntPathRequestMatcher("/configuration/security"),
+                new AntPathRequestMatcher("/swagger-ui.html"),
+                new AntPathRequestMatcher("/webjars/**"),
+                new AntPathRequestMatcher("/swagger/**"),
+                new AntPathRequestMatcher("/v2/api-docs")
+        );
     }
 }

--- a/src/main/java/yapp/bestFriend/config/security/JwtConfig.java
+++ b/src/main/java/yapp/bestFriend/config/security/JwtConfig.java
@@ -1,4 +1,4 @@
-package yapp.bestFriend.config;
+package yapp.bestFriend.config.security;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/yapp/bestFriend/config/security/SpringSecurityConfig.java
+++ b/src/main/java/yapp/bestFriend/config/security/SpringSecurityConfig.java
@@ -1,4 +1,4 @@
-package yapp.bestFriend.config;
+package yapp.bestFriend.config.security;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -35,8 +35,8 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
         http.addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class)
                 .formLogin().disable()
                 .csrf().disable() //csrf 공격으로부터 안전하고 매번 api 요청으로부터 csrf 토큰을 받지 않아도 되므로 disable 처리함
-                .cors().configurationSource(source())
-                .and().authorizeHttpRequests()
+                .cors().configurationSource(source()).and()
+                .authorizeHttpRequests() //인가에 대한 설정
                 .antMatchers("/api/oauth/**").permitAll()
                 .antMatchers("/api/token/**").permitAll()
                 .antMatchers("/h2-console/**").permitAll()
@@ -73,8 +73,8 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
     public void configure(WebSecurity web) {
         // swagger
         web.ignoring().antMatchers(
-                "/v2/api-docs",  "/configuration/ui",
+                "/v2/api-docs", "/configuration/ui",
                 "/swagger-resources", "/configuration/security",
-                "/swagger-ui.html", "/webjars/**","/swagger/**");
+                "/swagger-ui.html", "/webjars/**", "/swagger/**");
     }
 }

--- a/src/main/java/yapp/bestFriend/model/utils/JwtUtil.java
+++ b/src/main/java/yapp/bestFriend/model/utils/JwtUtil.java
@@ -1,8 +1,6 @@
 package yapp.bestFriend.model.utils;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import yapp.bestFriend.model.entity.Role;
 import yapp.bestFriend.service.user.UserDetails;
@@ -74,14 +72,10 @@ public class JwtUtil {
 
     // 토큰의 유효성 + 만료일자 확인
     public static Claims getClaimsFromToken(String token) {
-        try{
-            return Jwts.parserBuilder()
+        return Jwts.parserBuilder()
                 .setSigningKey(key)
                 .build().parseClaimsJws(token)
-                    .getBody();
-        }catch (Exception e){
-            return null;
-        }
+                .getBody();
     }
 
     public boolean validateToken(String token, UserDetails userDetails) {

--- a/src/main/java/yapp/bestFriend/service/user/SessionService.java
+++ b/src/main/java/yapp/bestFriend/service/user/SessionService.java
@@ -28,13 +28,14 @@ public class SessionService {
         }
 
         String jwtToken = token.substring("Bearer ".length());
-        Claims claims = JwtUtil.getClaimsFromToken(jwtToken);
-        if (claims == null){
+        Claims claims;
+        try{
+            claims = JwtUtil.getClaimsFromToken(jwtToken);
+        }catch (Exception e){
             return DefaultRes.response(HttpStatus.UNAUTHORIZED.value(), "토큰불일치");
         }
 
         String tokenName = claims.get("token_name", String.class);
-        String userGrade = claims.get("user_grade", String.class);
 
         if(tokenName.equals(JwtUtil.REFRESH_TOKEN_NAME)){
 
@@ -56,12 +57,6 @@ public class SessionService {
     public Boolean refreshTokenCheck(Long id, String refreshToken){
         Optional<User> optionalUser = userRepository.findById(id);
 
-        return optionalUser.map(user -> {
-            if(user.getToken().equals(refreshToken)){
-                return true;
-            }else{
-                return false;
-            }
-        }).orElse(false);
+        return optionalUser.map(user -> user.getToken().equals(refreshToken)).orElse(false);
     }
 }

--- a/src/test/java/yapp/bestFriend/controller/SampleControllerTest.java
+++ b/src/test/java/yapp/bestFriend/controller/SampleControllerTest.java
@@ -3,6 +3,7 @@ package yapp.bestFriend.controller;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan;
@@ -33,6 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(controllers = SampleController.class, includeFilters = {
         // to include JwtUtil in spring context
         @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtUtil.class)})
+@AutoConfigureMockMvc(addFilters = false)
 class SampleControllerTest {
 
     @Autowired
@@ -52,7 +54,7 @@ class SampleControllerTest {
     @WithMockUser(roles = "USER")
     public void socialLoginType() throws Exception {
         mvc.perform(get("/sample")
-                .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.message", equalTo("정상")))
                 .andDo(print())
                 .andExpect(status().isOk());
@@ -66,8 +68,8 @@ class SampleControllerTest {
         String password = "1234";
 
         mvc.perform(get("/sample/param")
-                    .param("email", email)
-                    .param("password", password))
+                        .param("email", email)
+                        .param("password", password))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.email", is(email)))
                 .andExpect(jsonPath("$.data.password", is(password)));

--- a/src/test/java/yapp/bestFriend/controller/api/token/ReplaceTokenControllerTest.java
+++ b/src/test/java/yapp/bestFriend/controller/api/token/ReplaceTokenControllerTest.java
@@ -1,0 +1,95 @@
+package yapp.bestFriend.controller.api.token;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import yapp.bestFriend.model.dto.DefaultRes;
+import yapp.bestFriend.model.dto.res.ReplaceTokenResponseDto;
+import yapp.bestFriend.model.utils.JwtUtil;
+import yapp.bestFriend.service.user.SessionService;
+import yapp.bestFriend.service.user.UserDetailsService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = ReplaceTokenController.class)
+@ExtendWith(MockitoExtension.class)
+@AutoConfigureMockMvc(addFilters = false)
+class ReplaceTokenControllerTest {
+
+    MockHttpServletRequest request;
+
+    @Autowired
+    MockMvc mvc;
+
+    @MockBean
+    SessionService sessionService;
+
+    @MockBean
+    UserDetailsService userDetailsService;
+
+    @MockBean
+    PasswordEncoder passwordEncoder;
+
+    @MockBean
+    private JwtUtil jwtUtil;
+
+    @Test
+    @DisplayName("액세스 토큰 재발급 Test")
+    public void recreate_access_token() throws Exception {
+        //given
+        String accessToken = "thisIsTestToken";
+        request = new MockHttpServletRequest();
+
+        DefaultRes result = new DefaultRes<>(HttpStatus.OK.value(),
+                "토큰재발급",
+                new ReplaceTokenResponseDto(accessToken));
+
+        //when
+        when(sessionService.replaceToken(any(MockHttpServletRequest.class))).thenReturn(result);
+
+        //then
+        mvc.perform(get("/api/token", request))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode", CoreMatchers.is(200)))
+                .andExpect(jsonPath("$.data.accessToken", CoreMatchers.notNullValue()))
+                .andExpect(jsonPath("$.message", CoreMatchers.is("토큰재발급")));
+    }
+
+    @Test
+    @DisplayName("토큰 없이 액세스 토큰 발급 요청")
+    public void request_error() throws Exception {
+        //given
+        String accessToken = "thisIsTestToken";
+        request = new MockHttpServletRequest();
+
+        DefaultRes result = DefaultRes.builder().statusCode(HttpStatus.UNAUTHORIZED.value())
+                .Message("요청에러").build();
+
+        //when
+        when(sessionService.replaceToken(any(MockHttpServletRequest.class))).thenReturn(result);
+
+        //then
+        mvc.perform(get("/api/token", request))
+                .andDo(print())
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.statusCode", CoreMatchers.is(HttpStatus.UNAUTHORIZED.value())))
+                .andExpect(jsonPath("$.message", CoreMatchers.is("요청에러")));
+    }
+
+}

--- a/src/test/java/yapp/bestFriend/service/user/SessionServiceTest.java
+++ b/src/test/java/yapp/bestFriend/service/user/SessionServiceTest.java
@@ -1,0 +1,45 @@
+package yapp.bestFriend.service.user;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import yapp.bestFriend.repository.UserRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class SessionServiceTest {
+
+    MockHttpServletRequest request;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("토큰 없음")
+    void no_token(){
+        request = new MockHttpServletRequest();
+
+        SessionService sessionService = new SessionService(userRepository);
+
+        assertThat(sessionService.replaceToken(request))
+                .hasFieldOrPropertyWithValue("statusCode",401)
+                .hasFieldOrPropertyWithValue("Message","요청에러");
+    }
+
+    @Test
+    @DisplayName("토큰불일치")
+    void invalid_token(){
+        request = new MockHttpServletRequest();
+        request.addHeader("Authorization","Bearer ");
+
+        SessionService sessionService = new SessionService(userRepository);
+
+        assertThat(sessionService.replaceToken(request))
+                .hasFieldOrPropertyWithValue("statusCode",401)
+                .hasFieldOrPropertyWithValue("Message","토큰불일치");
+    }
+}


### PR DESCRIPTION
## api 요청 시 jwt 토큰 검사 후 반환 메시지 세분화
1. 잘못된 토큰을 보낸 경우
![401 유효하지 않은 토큰](https://user-images.githubusercontent.com/40281615/170914556-0ad44a44-cdf9-47cc-98e7-320d41d82dfb.png)
2. 만료된 액세스 토큰을 보낸 경우
![401 토큰 만료](https://user-images.githubusercontent.com/40281615/170914561-dc4462e1-6a49-4827-ba15-c39cebe2d9af.png)
3. 토큰을 안보낸 경우
![401 토큰 없음](https://user-images.githubusercontent.com/40281615/170914562-ee2cb152-12ff-45ba-98b3-35691f1d30f2.png)
4. 그 외 기존과 동일하게 http status code 403 반환
