### PR TITLE
소셜로그인 Rest API 방식 -> 안드로이드 SDK 방식으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 
 	//static method 테스트를 위한 mockito-line 추가
 	testImplementation 'org.mockito:mockito-inline:3.11.2'
+
+	// 쿼리파라미터 로그확인용 외부 라이브러리
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0'
 }
 
 //querydsl 추가 시작

--- a/src/main/java/yapp/bestFriend/controller/ProductController.java
+++ b/src/main/java/yapp/bestFriend/controller/ProductController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import yapp.bestFriend.model.dto.DefaultRes;
 import yapp.bestFriend.model.dto.request.CreateProductRequest;
 import yapp.bestFriend.model.dto.request.UpdateProductRequest;
-import yapp.bestFriend.model.dto.response.SimpleProductResponse;
+import yapp.bestFriend.model.dto.res.SimpleProductResponse;
 import yapp.bestFriend.model.utils.UserUtil;
 import yapp.bestFriend.service.ProductService;
 

--- a/src/main/java/yapp/bestFriend/controller/api/auth/OauthController.java
+++ b/src/main/java/yapp/bestFriend/controller/api/auth/OauthController.java
@@ -6,10 +6,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
 import yapp.bestFriend.model.dto.DefaultRes;
+import yapp.bestFriend.model.dto.request.SocialLoginRequest;
 import yapp.bestFriend.model.enumClass.SocialLoginType;
 import yapp.bestFriend.service.auth.OauthService;
 
+import javax.validation.Valid;
+
+/* 22-06-05 : Rest API 방식 -> 안드로이드 SDK 방식으로 변경
+ * */
 @Api(tags = {"소셜 로그인 API"})
 @RestController
 @RequiredArgsConstructor
@@ -17,6 +23,17 @@ import yapp.bestFriend.service.auth.OauthService;
 @Slf4j
 public class OauthController {
     private final OauthService oauthService;
+
+    @ApiOperation(value = "소셜로그인 API",notes = "소셜로그인 API 입니다.")
+    @ApiParam("KAKAO")
+    @ApiResponses(value ={
+            @ApiResponse(code = 200, message = "등록 성공"),
+    })
+    @PostMapping(value = "/{socialLoginType}")
+    public ResponseEntity<DefaultRes> SocialLoginRequest(@PathVariable(name = "socialLoginType") SocialLoginType socialLoginType,
+                                                         @Valid @RequestBody SocialLoginRequest request){
+        return new ResponseEntity<>(oauthService.requestLogin(socialLoginType, request), HttpStatus.OK);
+    }
 
     /**
      * 사용자로부터 SNS 로그인 요청을 Social Login Type 을 받아 처리
@@ -28,6 +45,7 @@ public class OauthController {
     })
     @ApiParam("KAKAO")
     @GetMapping(value = "/{socialLoginType}")
+    @ApiIgnore
     public ResponseEntity<DefaultRes> socialLoginType(
             @PathVariable(name = "socialLoginType") SocialLoginType socialLoginType) {
         log.info(">> 사용자로부터 SNS 로그인 요청을 받음 :: {} Social Login", socialLoginType);
@@ -35,17 +53,18 @@ public class OauthController {
         return new ResponseEntity<>(oauthService.request(socialLoginType), HttpStatus.OK);
     }
 
-    /**
-     * Social Login API Server 요청에 의한 callback 을 처리
-     * @param socialLoginType (GOOGLE, FACEBOOK)
-     * @param code API Server 로부터 넘어노는 code
-     * @return SNS Login 요청 결과로 받은 Json 형태의 String 문자열 (access_token, refresh_token 등)
-     */
-    @GetMapping(value = "/callback/{socialLoginType}")
-    public ResponseEntity<DefaultRes> callback(
-            @PathVariable(name = "socialLoginType") SocialLoginType socialLoginType,
-            @RequestParam(name = "code") String code) {
-        log.info(">> 소셜 로그인 API 서버로부터 받은 code :: {}", code);
-        return new ResponseEntity<>(oauthService.requestAccessToken(socialLoginType, code), HttpStatus.OK);
-    }
+//    /**
+//     * Social Login API Server 요청에 의한 callback 을 처리
+//     * @param socialLoginType (GOOGLE, FACEBOOK)
+//     * @param code API Server 로부터 넘어노는 code
+//     * @return SNS Login 요청 결과로 받은 Json 형태의 String 문자열 (access_token, refresh_token 등)
+//     */
+//    @GetMapping(value = "/callback/{socialLoginType}")
+//    @ApiIgnore
+//    public ResponseEntity<DefaultRes> callback(
+//            @PathVariable(name = "socialLoginType") SocialLoginType socialLoginType,
+//            @RequestParam(name = "code") String code) {
+//        log.info(">> 소셜 로그인 API 서버로부터 받은 code :: {}", code);
+//        return new ResponseEntity<>(oauthService.requestAccessToken(socialLoginType, code), HttpStatus.OK);
+//    }
 }

--- a/src/main/java/yapp/bestFriend/controller/api/savingRecord/SavingRecordController.java
+++ b/src/main/java/yapp/bestFriend/controller/api/savingRecord/SavingRecordController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import yapp.bestFriend.model.dto.DefaultRes;
 import yapp.bestFriend.model.dto.request.CheckProductRequest;
 import yapp.bestFriend.model.dto.res.SavingRecordDto;
+import yapp.bestFriend.model.dto.res.SavingRecordSummaryDto;
 import yapp.bestFriend.model.utils.UserUtil;
 import yapp.bestFriend.service.savingRecord.SavingRecordService;
 
@@ -41,6 +42,16 @@ public class SavingRecordController {
     @ApiImplicitParam(name = "recordMM", value = "기록 일자(YYYYMM) ex)202206", required = true, paramType = "query", defaultValue = "")
     public ResponseEntity<DefaultRes<List<SavingRecordDto>>> getSavingList(@RequestParam("recordMM") String recordMM){
         return new ResponseEntity<>(savingRecordService.getSavingList(UserUtil.getId(), recordMM), HttpStatus.OK);
+    }
+
+    @ApiOperation(value = "절약 기록 Summary API", notes = "해당월의 전월대비 절약 기록 Summary를 제공해주는 API 입니다.")
+    @ApiResponses(value ={
+            @ApiResponse(code = 200, message = "1. 조회 성공 \t\n 2. 조회 실패(사용자 정보 없음) \t\n 3.조회실패(기록일자 파라미터 오류) \t\n 4. 데이터 없음 \t\n")
+    })
+    @GetMapping("/savingRecords/summary")
+    @ApiImplicitParam(name = "recordMM", value = "기록 일자(YYYYMM) ex)202206", required = true, paramType = "query", defaultValue = "")
+    public ResponseEntity<DefaultRes<List<SavingRecordSummaryDto>>> getSavingSummary(@RequestParam("recordMM") String recordMM){
+        return new ResponseEntity<>(savingRecordService.getSavingSummary(UserUtil.getId(), recordMM), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/yapp/bestFriend/model/dto/request/CheckProductRequest.java
+++ b/src/main/java/yapp/bestFriend/model/dto/request/CheckProductRequest.java
@@ -1,5 +1,7 @@
 package yapp.bestFriend.model.dto.request;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,6 +9,8 @@ import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class CheckProductRequest {
 
     private Long userId;

--- a/src/main/java/yapp/bestFriend/model/dto/request/SocialLoginRequest.java
+++ b/src/main/java/yapp/bestFriend/model/dto/request/SocialLoginRequest.java
@@ -1,0 +1,28 @@
+package yapp.bestFriend.model.dto.request;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SocialLoginRequest {
+
+    @NotNull
+    @ApiModelProperty(value = "사용자의 SNS 고유 ID", example = "2242469369")
+    private Long providerId;
+
+    @NotNull
+    @ApiModelProperty(value = "사용자의 SNS email 주소", example = "test@naver.com")
+    private String email;
+
+    @NotNull
+    @ApiModelProperty(value = "사용자의 SNS 닉네임", example = "best friend")
+    private String nickName;
+}

--- a/src/main/java/yapp/bestFriend/model/dto/res/SavingRecordSummaryDto.java
+++ b/src/main/java/yapp/bestFriend/model/dto/res/SavingRecordSummaryDto.java
@@ -1,0 +1,37 @@
+package yapp.bestFriend.model.dto.res;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SavingRecordSummaryDto {
+
+    @ApiModelProperty(value = "기록 기준월", example = "202205")
+    private String recordMM;
+
+    @ApiModelProperty(value = "절약 상품의 이름", example = "빙수")
+    private String name;
+
+    @ApiModelProperty(value = "이번달 절약 횟수", example = "2")
+    private Integer baseTimes;
+
+    @ApiModelProperty(value = "지난달 절약 횟수", example = "1")
+    private Integer prevTimes;
+
+    @ApiModelProperty(value = "직전월 대비 횟수", example = "1")
+    private Integer timesComparedToPrev;
+
+    public SavingRecordSummaryDto(SavingRecordSummaryInterface input) {
+        this.recordMM = input.getRecordMm();
+        this.name = input.getProductName();
+        this.baseTimes = input.getBaseTimes();
+        this.prevTimes = input.getPrevTimes();
+        this.timesComparedToPrev = input.getTimesComparedToPrev();
+    }
+}

--- a/src/main/java/yapp/bestFriend/model/dto/res/SavingRecordSummaryInterface.java
+++ b/src/main/java/yapp/bestFriend/model/dto/res/SavingRecordSummaryInterface.java
@@ -1,0 +1,9 @@
+package yapp.bestFriend.model.dto.res;
+
+public interface SavingRecordSummaryInterface {
+    String getRecordMm();
+    String getProductName();
+    Integer getBaseTimes();
+    Integer getPrevTimes();
+    Integer getTimesComparedToPrev();
+}

--- a/src/main/java/yapp/bestFriend/model/dto/res/SimpleProductResponse.java
+++ b/src/main/java/yapp/bestFriend/model/dto/res/SimpleProductResponse.java
@@ -1,10 +1,9 @@
-package yapp.bestFriend.model.dto.response;
+package yapp.bestFriend.model.dto.res;
 
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
 

--- a/src/main/java/yapp/bestFriend/model/entity/BaseInfo.java
+++ b/src/main/java/yapp/bestFriend/model/entity/BaseInfo.java
@@ -44,4 +44,8 @@ public abstract class BaseInfo {
     public void delete() {
         this.deletedYn = true;
     }
+
+    public void restore() {
+        this.deletedYn = false;
+    }
 }

--- a/src/main/java/yapp/bestFriend/repository/SavingRecordRepository.java
+++ b/src/main/java/yapp/bestFriend/repository/SavingRecordRepository.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 import yapp.bestFriend.model.dto.res.SavingRecordSummaryInterface;
 import yapp.bestFriend.model.entity.SavingRecord;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
@@ -36,4 +37,6 @@ public interface SavingRecordRepository extends JpaRepository<SavingRecord, Long
             ")",
             nativeQuery = true)
     List<SavingRecordSummaryInterface> selectSummary(@Param(value = "fromDate") String fromDate, @Param(value = "toDate") String toDate, @Param(value = "userId") Long userId);
+
+    List<SavingRecord> findSavingRecordsByProductIdAndUserIdAndRecordYmdAndDeletedYn(LocalDate recordYmd, Long productId, Long userId, Boolean DeletedYn); // where name = ? and ranking = ?
 }

--- a/src/main/java/yapp/bestFriend/repository/SavingRecordRepository.java
+++ b/src/main/java/yapp/bestFriend/repository/SavingRecordRepository.java
@@ -1,9 +1,39 @@
 package yapp.bestFriend.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import yapp.bestFriend.model.dto.res.SavingRecordSummaryInterface;
 import yapp.bestFriend.model.entity.SavingRecord;
+
+import java.util.List;
 
 @Repository
 public interface SavingRecordRepository extends JpaRepository<SavingRecord, Long> {
+
+    // SQL 일반 파라미터 쿼리, @Param 사용 O
+    @Query(value =
+            "WITH SUMMMARY AS (\n" +
+            "    SELECT SUBSTR(A.RECORD_YMD,1,7) AS RECORD_MM,\n" +
+            "           B.PRODUCT_NAME,\n" +
+            "           SUM(DECODE(SUBSTR(A.RECORD_YMD,1,7),:toDate,1,0)) BASE_TIMES,\n" +
+            "           SUM(DECODE(SUBSTR(A.RECORD_YMD,1,7),:fromDate,1,0)) PREV_TIMES\n" +
+            "    From SAVING_RECORD A, PRODUCT B\n" +
+            "    WHERE A.PRODUCT_ID = B.PRODUCT_ID\n" +
+            "      AND A.USER_ID = B.USER_ID\n" +
+            "      AND A.USER_ID = :userId\n" +
+            "      AND A.RECORD_YMD BETWEEN PARSEDATETIME (:fromDate||'-01','yyyy-MM-dd') and PARSEDATETIME (:toDate||'-31','yyyy-MM-dd')\n" +
+            "    GROUP BY SUBSTR(A.RECORD_YMD,1,7), B.PRODUCT_NAME\n" +
+            ")\n" +
+            "SELECT RECORD_MM as recordMm, PRODUCT_NAME as productName, BASE_TIMES as baseTimes, PREV_TIMES as prevTimes, BASE_TIMES-PREV_TIMES AS timesComparedToPrev\n" +
+            "  FROM (\n" +
+            "    SELECT RECORD_MM, PRODUCT_NAME, CAST(NVL(SUM(BASE_TIMES),0) AS INT) AS BASE_TIMES,\n" +
+            "           CAST(NVL(SUM((SELECT PREV_TIMES FROM SUMMMARY WHERE RECORD_MM = :fromDate AND PRODUCT_NAME = A.PRODUCT_NAME)),0) AS INT) AS PREV_TIMES\n" +
+            "      FROM SUMMMARY A\n" +
+            "    WHERE RECORD_MM = :toDate\n" +
+            "    GROUP BY PRODUCT_NAME\n" +
+            ")",
+            nativeQuery = true)
+    List<SavingRecordSummaryInterface> selectSummary(@Param(value = "fromDate") String fromDate, @Param(value = "toDate") String toDate, @Param(value = "userId") Long userId);
 }

--- a/src/main/java/yapp/bestFriend/repository/SavingRecordRepositoryCustom.java
+++ b/src/main/java/yapp/bestFriend/repository/SavingRecordRepositoryCustom.java
@@ -6,7 +6,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import yapp.bestFriend.model.dto.res.SavingRecordDto;
-import yapp.bestFriend.model.dto.response.SimpleProductResponse;
+import yapp.bestFriend.model.dto.res.SimpleProductResponse;
 import yapp.bestFriend.model.entity.Product;
 import yapp.bestFriend.model.entity.User;
 

--- a/src/main/java/yapp/bestFriend/repository/SavingRecordRepositoryCustom.java
+++ b/src/main/java/yapp/bestFriend/repository/SavingRecordRepositoryCustom.java
@@ -27,7 +27,8 @@ public class SavingRecordRepositoryCustom {
                 .from(savingRecord)
                 .where(savingRecord.user.eq(existingUser)
                         .and(savingRecord.product.eq(product))
-                        .and(savingRecord.recordYmd.eq(now)))
+                        .and(savingRecord.recordYmd.eq(now))
+                        .and(savingRecord.deletedYn.eq(false)))
                 .fetchFirst();
 
         return fetchOne != null;

--- a/src/main/java/yapp/bestFriend/service/ProductService.java
+++ b/src/main/java/yapp/bestFriend/service/ProductService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import yapp.bestFriend.model.dto.DefaultRes;
 import yapp.bestFriend.model.dto.request.CreateProductRequest;
 import yapp.bestFriend.model.dto.request.UpdateProductRequest;
-import yapp.bestFriend.model.dto.response.SimpleProductResponse;
+import yapp.bestFriend.model.dto.res.SimpleProductResponse;
 import yapp.bestFriend.model.entity.Product;
 import yapp.bestFriend.model.entity.User;
 import yapp.bestFriend.repository.ProductRepository;

--- a/src/main/java/yapp/bestFriend/service/auth/OauthService.java
+++ b/src/main/java/yapp/bestFriend/service/auth/OauthService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import yapp.bestFriend.model.dto.DefaultRes;
+import yapp.bestFriend.model.dto.request.SocialLoginRequest;
 import yapp.bestFriend.model.enumClass.SocialLoginType;
 
 import java.util.List;
@@ -14,11 +15,12 @@ public class OauthService {
     private final List<SocialOauth> socialOauthList;
     private final KakaoOauth kakaoOauth;
 
-    public DefaultRes request(SocialLoginType socialLoginType) {
-        SocialOauth socialOauth = this.findSocialOauthByType(socialLoginType);
-        String redirectURL = socialOauth.getOauthRedirectURL();
+    public DefaultRes requestLogin(SocialLoginType socialLoginType, SocialLoginRequest request) {
+        if(socialLoginType == SocialLoginType.KAKAO){
+            return kakaoOauth.requestAccessTokenUsingUserData(request);
+        }
 
-        return DefaultRes.response(HttpStatus.OK.value(), "리다이렉트주소", redirectURL);
+        return DefaultRes.response(HttpStatus.OK.value(), "등록실패 (소셜 로그인 타입 없음)");
     }
 
     private SocialOauth findSocialOauthByType(SocialLoginType socialLoginType) {
@@ -28,14 +30,21 @@ public class OauthService {
                 .orElseThrow(() -> new IllegalArgumentException("알 수 없는 SocialLoginType 입니다."));
     }
 
-    public DefaultRes requestAccessToken(SocialLoginType socialLoginType, String code) {
+//    public DefaultRes requestAccessToken(SocialLoginType socialLoginType, String code) {
+//        SocialOauth socialOauth = this.findSocialOauthByType(socialLoginType);
+//
+//        if(socialLoginType == SocialLoginType.KAKAO){
+//            String token = socialOauth.requestAccessToken(code);
+//            return kakaoOauth.requestAccessTokenUsingURL(token);
+//        }
+//
+//        return DefaultRes.response(HttpStatus.OK.value(), "등록실패");
+//    }
+
+    public DefaultRes request(SocialLoginType socialLoginType) {
         SocialOauth socialOauth = this.findSocialOauthByType(socialLoginType);
+        String redirectURL = socialOauth.getOauthRedirectURL();
 
-        if(socialLoginType == SocialLoginType.KAKAO){
-            String token = socialOauth.requestAccessToken(code);
-            return kakaoOauth.requestAccessTokenUsingURL(token);
-        }
-
-        return DefaultRes.response(HttpStatus.OK.value(), "등록실패");
+        return DefaultRes.response(HttpStatus.OK.value(), "리다이렉트주소", redirectURL);
     }
 }

--- a/src/test/java/yapp/bestFriend/repository/SavingRecordRepositoryCustomTest.java
+++ b/src/test/java/yapp/bestFriend/repository/SavingRecordRepositoryCustomTest.java
@@ -1,7 +1,6 @@
 package yapp.bestFriend.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,7 +27,6 @@ import static org.assertj.core.groups.Tuple.tuple;
         classes = JpaAuditingConfig.class
 ))
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Slf4j
 class SavingRecordRepositoryCustomTest {
 
     @Autowired


### PR DESCRIPTION
## 절약 등록 API 수정 - /api/products
 - 상세 수정 내용
   - 체크된 항목에 대해 재체크 시 기록 항목 soft-delete
   - Test: 기록 최초 등록하는 경우, 삭제했던 기록 다시 체크하는 경우, 기록 체크 해제하는 경우
 - 테스트
   - 체크하려는 항목이 절약 대상 리스트에 없는 경우
  
![220628 절약체크 API - 절약 항목이 없는 경우](https://user-images.githubusercontent.com/40281615/172505118-f88293a2-483b-479e-b13a-e3b083a7e294.png)

## 절약 기록 Summary API 추가 - /api/products/summary
- 정상조회

![220628 절약기록 Summary API - 정상조회](https://user-images.githubusercontent.com/40281615/172505810-c7cb9d9b-f07f-4ed2-95ae-9b46293d4fbb.png)

 - 파라미터로 주어진 해당 월에 절약 기록이 없는 경우

![220628 절약기록 Summary API - 절약 기록이 없는 경우](https://user-images.githubusercontent.com/40281615/172505692-e973f6cd-df8e-4776-abfe-839442938aee.png)

[ 그 외 ]
- 소셜로그인 Rest API 방식 -> 안드로이드 SDK 방식으로 변경
- Move: product class 파일 위치 변경
- Chore: 쿼리파라미터 로그 확인용 외부 라이브러리 의존성 추가